### PR TITLE
Updated module poms to match parent version

### DIFF
--- a/beta-start-page/pom.xml
+++ b/beta-start-page/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-cms-foundation</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kestros-cms-foundation-beta-start-page</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-cms-foundation</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kestros-cms-foundation-docs</artifactId>

--- a/filetypes/pom.xml
+++ b/filetypes/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-cms-foundation</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1-SNAPSHOT</version>
   </parent>
 
   <groupId>io.kestros.cms</groupId>

--- a/managed-versioning/pom.xml
+++ b/managed-versioning/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-cms-foundation</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1-SNAPSHOT</version>
   </parent>
 
   <groupId>io.kestros.cms</groupId>

--- a/modeltypes/pom.xml
+++ b/modeltypes/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-cms-foundation</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1-SNAPSHOT</version>
   </parent>
 
   <groupId>io.kestros.cms</groupId>

--- a/performance-services/pom.xml
+++ b/performance-services/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-cms-foundation</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1-SNAPSHOT</version>
   </parent>
 
   <groupId>io.kestros.cms</groupId>

--- a/startup/pom.xml
+++ b/startup/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-cms-foundation</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1-SNAPSHOT</version>
   </parent>
 
   <packaging>bundle</packaging>


### PR DESCRIPTION
These changes plus an update to kestros-root fixed my build errors in this repository.